### PR TITLE
Fix SemanticScreenReaderImplementation on Windows

### DIFF
--- a/Avalonia.Maui/Platforms/Windows/Patches.cs
+++ b/Avalonia.Maui/Platforms/Windows/Patches.cs
@@ -144,5 +144,30 @@ namespace Avalonia.Maui.Platforms.Windows
 
         }
     }
+
+    [HarmonyPatch]
+    class SemanticScreenReaderPatch
+    {
+    	// This method tells Harmony which method to patch
+        static MethodBase TargetMethod()
+        {
+            // Find the internal type by full name
+            var type = AccessTools.TypeByName("Microsoft.Maui.Accessibility.SemanticScreenReaderImplementation");
+            if (type == null)
+                throw new Exception("Could not find SemanticScreenReaderImplementation type");
+
+            // Find the Announce method with a string parameter
+            return AccessTools.Method(type, "Announce", new Type[] { typeof(string) });
+        }
+
+		// Prefix runs before original method; returning false skips original    
+    	static bool Prefix(string text)
+        {
+			// We provide a fake window as a stub. As of 17.09.2026, Microsoft's implementation of the 
+			// SemanticScreenReaderImplementation.Announce() doesn't handle an absence of the automation peer correctly
+			// and crashes with AV.
+    		return false; 
+        }
+    }
 }
 #endif


### PR DESCRIPTION
### Why this PR?
The recent version of Syncfusion MAUI (31.1.20) crashes the app when using certain controls.  Discovered in `SfTabView` that is integrated into `SfPdfViewer`. 

### Error reason
`SfTabView` utilizes accessibility features exposed through the `SemanticScreenReader` API. Microsoft's default implementation for UWP has a bug that causes AV. [Here](https://github.com/dotnet/maui/blob/3273d2bf7b48208968cec958cd3eb01690c777ba/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.uwp.cs#L20) returned automation peer can be `null`, but no check is implemented. 
Avalonia's MAUI host control provides a fake window with no content, which triggers an AV exception.

### Other possible solutions
Set up the MAUI window so that it provides a non-nullable `Content` with at least one child that can be treated as an automation peer. This will fit Microsoft's logic.