### PR TITLE
Fix IDispatcher registration on Windows

### DIFF
--- a/Avalonia.Maui/AvaloniaAppBuilderExtensions.cs
+++ b/Avalonia.Maui/AvaloniaAppBuilderExtensions.cs
@@ -58,6 +58,7 @@ public static class AvaloniaAppBuilderExtensions
 	                .AddSingleton<UIWindow>(static p => p.GetService<IUIApplicationDelegate>()!.GetWindow())
 #elif WINDOWS10_0_19041_0_OR_GREATER
                     .AddKeyedSingleton<IDispatcher, Platforms.Windows.AppDispatcher>(typeof(IApplication))
+					.AddSingleton<IDispatcher, Platforms.Windows.AppDispatcher>()
                     .AddSingleton(Microsoft.UI.Xaml.Application.Current)
 #endif
                     .AddSingleton<IMauiInitializeService, MauiEmbeddingInitializer>();


### PR DESCRIPTION
### Why this PR?

The versions of Syncfusion MAUI starting from 23.x require the `IDispatcher` service. Otherwise, the `AppBuilder` crashes with an exception at line [67](https://github.com/AvaloniaUI/AvaloniaMauiHybrid/blob/9f16117c0edbced6d7683a8b74536fc9a0d143cd/Avalonia.Maui/AvaloniaAppBuilderExtensions.cs#L67).

#### Remarks
I'm not sure why the keyed registration is required? Probably it is enough to keep only unkeyed?