### PR TITLE
Fix packaging on Windows

### DIFF
--- a/Avalonia.Maui/Avalonia.Maui.csproj
+++ b/Avalonia.Maui/Avalonia.Maui.csproj
@@ -65,6 +65,11 @@
 		<None Include="Icon.png" Pack="true" Visible="false" PackagePath="" />
 	</ItemGroup>
 
+    <!-- Force include Icon.png in lib folder for Windows build -->
+    <ItemGroup>
+        <None Include="Icon.png" Pack="true" Visible="false" PackagePath="lib\net8.0-windows10.0.19041\Avalonia.Maui" />        
+    </ItemGroup>
+
 	<ItemGroup>
 	  <None Update="Platforms\Windows\GeneratedApp.tt">
 	    <Generator>TextTemplatingFileGenerator</Generator>


### PR DESCRIPTION
### Why this PR?

For the Windows version, the icon resource is referenced in the PRI file but not delivered with the NuGet package. This prevents the consumer project from compiling. The icon is correctly deployed to the output folder, but for some reason, it is not included in the NuGet package.

Note that the sample project compiles, because it doesn't use the package.